### PR TITLE
changed optional argument syntax of \img command (img.js extension) to be more LaTeX-like

### DIFF
--- a/img/README.md
+++ b/img/README.md
@@ -17,12 +17,16 @@ Provides a macro for embedding images in math.
 
 # Usage:
 
-    \img{URL}{vertical alignment}{width}{height}
+    \img[valign=<vertical alignment>,width=<width>,height=<height>]{URL}
+
+or
+
+    \img[<vertical alignment>][<width>][<height>]{URL}
 
 This adds an `\img` macro for inserting images into a MathJax expression.  
-It takes 4 arguments:  the URL for the image, the vertical alignment value, 
-the width, and the height of the image.  Any of the final three can be 
-blank in order to use the default.  
+Apart from the URL for the image, it takes three optional parameters:
+The vertical alignment value, the width, and the height of the image.
+Leave them out to get default values.
 
 With no vertical-align value, the image will sit on the baseline.  With 
 not width or height, the image will be its natural size.  With one of 

--- a/img/unpacked/img.js
+++ b/img/unpacked/img.js
@@ -6,7 +6,9 @@
  *
  *  Usage:
  *
- *  \img{URL}{vertical alignment}{width}{height}
+ *  \img[valign=<vertical alignment>,width=<width>,height=<height>]{URL}
+ *  or
+ *  \img[<valign>][<width>][<height>]{URL}
  *
  *  ---------------------------------------------------------------------
  *
@@ -40,14 +42,39 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
           TEX.Definitions.macros.img = "myImage";
           TEX.Parse.Augment({
             myImage: function (name) {
-              var src = this.GetArgument(name),
-                  valign = CheckDimen(this.GetArgument(name)),
-                  width  = CheckDimen(this.GetArgument(name)),
-                  height = CheckDimen(this.GetArgument(name));
-              var def = {src:src};
-              if (valign) {def.valign = valign}
-              if (width)  {def.width  = width}
-              if (valign) {def.height = height}
+              var optarg = this.GetBrackets(name,'');
+              var def = {
+                valign: '',
+                width: '',
+                height: ''
+              };
+              if(optarg.indexOf(',') !== -1 || optarg.indexOf('=') !== -1){
+                // keyval param
+                var opts = optarg.split(',');
+                for(var i=0,l=opts.length;i<l;++i){
+                  var parts = opts[i].split('=');
+                  var key = parts[0].trim();
+                  if(!key)
+                    TEX.Error('Empty key in "'+optarg+'"');
+                  /* empty values are ok:
+                  if(parts.length<2)
+                    TEX.Error('Empty value for parameter "'+key+'"');
+                  */
+                  if(!(key in def))
+                    TEX.Error('Unknown parameter "'+key+'"');
+                  var val = parts.slice(1).join('=');
+                  val = CheckDimen(val);
+                  def[key] = val;
+                }
+              } else {
+                def.valign = CheckDimen(optarg);
+                def.width = CheckDimen(this.GetBrackets(name,''));
+                def.height = CheckDimen(this.GetBrackets(name,''));
+              }
+              def.src = this.GetArgument(name);
+              if (!def.valign) { delete def.valign; }
+              if (!def.width)  { delete def.width; }
+              if (!def.height) { delete def.height; }
               this.Push(this.mmlToken(MML.mglyph().With(def)));
             }
           });

--- a/img/unpacked/img.js
+++ b/img/unpacked/img.js
@@ -54,14 +54,12 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
                 for(var i=0,l=opts.length;i<l;++i){
                   var parts = opts[i].split('=');
                   var key = parts[0].trim();
-                  if(!key)
-                    TEX.Error('Empty key in "'+optarg+'"');
                   /* empty values are ok:
                   if(parts.length<2)
                     TEX.Error('Empty value for parameter "'+key+'"');
                   */
                   if(!(key in def))
-                    TEX.Error('Unknown parameter "'+key+'"');
+                    TEX.Error(['UnknownKey','Unknown parameter in %1',key]);
                   var val = parts.slice(1).join('=');
                   val = CheckDimen(val);
                   def[key] = val;

--- a/img/unpacked/img.js
+++ b/img/unpacked/img.js
@@ -53,12 +53,12 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
                 var opts = optarg.split(',');
                 for(var i=0,l=opts.length;i<l;++i){
                   var parts = opts[i].split('=');
-                  var key = parts[0].trim();
+                  var key = parts[0].replace(/^ +/,"").replace(/ +$/,"");
                   /* empty values are ok:
                   if(parts.length<2)
                     TEX.Error('Empty value for parameter "'+key+'"');
                   */
-                  if(!(key in def))
+                  if(!def.hasOwnProperty(key))
                     TEX.Error(['UnknownKey','Unknown parameter in %1',key]);
                   var val = parts.slice(1).join('=');
                   val = CheckDimen(val);


### PR DESCRIPTION
Optional arguments are now given either as 

    \img[valign=<valign>,width=<width>,height=<height>]{URL}

or

    \img[<valign>][<width>][<height>]{URL}

which are both common ways to supply optional parameters in LaTeX (the latter is usually used when there is just one optional argument). Example in http://jsfiddle.net/c6sy534g/ 