### PR TITLE
Updated link to  extension writing tutorial in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ in your configuration. See also the [documentation page on third party extension
 
 ## Writing extensions
 
-The MathJax documentation [contains a tutorial on extension writing](http://docs.mathjax.org/en/latest/extension-writing.html).
+The MathJax documentation [contains a tutorial on extension writing](http://docs.mathjax.org/en/latest/advanced/extension-writing.html).
 
 Afterwards, you might want to start by looking at some of the extensions here and [the MathJax core extensions](http://github.com/mathjax/MathJax/tree/master/unpacked/extensions).


### PR DESCRIPTION
Link to http://docs.mathjax.org/en/latest/advanced/extension-writing.html was broken.